### PR TITLE
Prevent having to pull php7 for doctrine/inflector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/process": "~2.3|~3.0",
         "zendframework/zendservice-apple-apns": "^1.1.0",
         "zendframework/zendservice-google-gcm": "1.*",
-        "doctrine/inflector": "~1.0"
+        "doctrine/inflector": "1.1"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"


### PR DESCRIPTION
Version 1.2 of doctrine/inflector requires php7